### PR TITLE
fix: Update API endpoint from /search to /search/jql to resolve 401 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ The plugin will detect urls like https://jira.secondlife.com/browse/OPEN-352 and
 - [ ] Issue can be extended JIRA:OPEN-353 with the summary
 - [x] Or compact JIRA:-OPEN-354 without the summary
 - [ ] JIRA:-OPEN-355 use the `-` symbol before the issue key to make it compact
+- [ ] JIRA:--OPEN-356 use `--` symbol to show only the status
 ```
 The plugin searches inside the note for those patterns and replace them
-JIRA:-OPEN-356
+JIRA:-OPEN-356 (compact mode)
+JIRA:--OPEN-357 (status only mode)
 ```
 ````
 ![Inline issues](./assets/inlineIssues.png)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-jira-issue",
   "name": "Jira Issue",
-  "version": "1.57.0",
+  "version": "1.58.0",
   "minAppVersion": "0.12.0",
   "description": "This plugin allows you to track the progress of Atlassian Jira issues from your Obsidian notes.",
   "author": "marc0l92",

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -3,12 +3,13 @@ import ObjectsCache from "../objectsCache"
 import { getActiveSprint, getActiveSprintName, getVelocity, getWorkLogByDates, getWorkLogBySprint, getWorkLogBySprintId, getWorkLogSeriesByUser } from "./apiMacro"
 import { getDefaultedSearchResults, getIssueDefaulted } from "./apiDefaulted"
 import { getWorklogPerDay, getWorklogPerUser } from "./apiChart"
-import { getBoards, getDevStatus, getIssue, getLoggedUser, getSearchResults, getSprint, getSprints } from "./apiBase"
+import { getBoards, getDevStatus, getIssue, getLoggedUser, getSearchResults, getSearchResultsCount, getSprint, getSprints } from "./apiBase"
 
 const API = {
     base: {
         getIssue: getIssue,
         getSearchResults: getSearchResults,
+        getSearchResultsCount: getSearchResultsCount,
         getDevStatus: getDevStatus,
         getBoards: getBoards,
         getSprint: getSprint,

--- a/src/api/apiBase.ts
+++ b/src/api/apiBase.ts
@@ -28,6 +28,10 @@ export async function getSearchResults(query: string, options: { limit?: number,
     return cacheWrapper(JiraClient.getSearchResults)(query, options)
 }
 
+export async function getSearchResultsCount(query: string, options: { account?: IJiraIssueAccountSettings } = {}): Promise<number> {
+    return cacheWrapper(JiraClient.getSearchResultsCount)(query, options)
+}
+
 export async function getDevStatus(issueId: string, options: { account?: IJiraIssueAccountSettings } = {}): Promise<IJiraDevStatus> {
     return cacheWrapper(JiraClient.getDevStatus)(issueId, options)
 }

--- a/src/client/jiraClient.ts
+++ b/src/client/jiraClient.ts
@@ -197,7 +197,7 @@ export default {
 
     async getSearchResults(query: string, options: { limit?: number, offset?: number, fields?: string[], account?: IJiraIssueAccountSettings } = {}): Promise<IJiraSearchResults> {
         const opt = {
-            fields: options.fields || [],
+            fields: options.fields || ['key', 'summary', 'status', 'assignee', 'reporter', 'priority', 'issuetype', 'created', 'updated', 'description', 'project'],
             offset: options.offset || 0,
             limit: options.limit || 50,
             account: options.account || null,
@@ -211,7 +211,7 @@ export default {
         const searchResults = await sendRequest(
             {
                 method: 'GET',
-                path: `/search`,
+                path: `/search/jql`,
                 queryParameters: queryParameters,
                 account: opt.account,
             }

--- a/src/interfaces/issueInterfaces.ts
+++ b/src/interfaces/issueInterfaces.ts
@@ -108,9 +108,12 @@ export interface IJiraUser {
 
 export interface IJiraSearchResults {
     issues: IJiraIssue[]
-    maxResults: number
-    startAt: number
-    total: number
+    maxResults?: number
+    startAt?: number
+    total?: number
+    nextPageToken?: string
+    isLast?: boolean
+    expand?: string
     account: IJiraIssueAccountSettings
 }
 

--- a/src/interfaces/settingsInterfaces.ts
+++ b/src/interfaces/settingsInterfaces.ts
@@ -18,6 +18,7 @@ export const COLOR_SCHEMA_DESCRIPTION = {
 }
 
 export const COMPACT_SYMBOL = '-'
+export const STATUS_ONLY_SYMBOL = '--'
 export const AVATAR_RESOLUTION = '16x16'
 export const COMMENT_REGEX = /^\s*#/
 export const JIRA_KEY_REGEX = '[A-Z][A-Z0-9_]*-[0-9]+'

--- a/src/rendering/inlineIssueRenderer.ts
+++ b/src/rendering/inlineIssueRenderer.ts
@@ -1,7 +1,7 @@
 import { MarkdownPostProcessorContext } from "obsidian"
 import JiraClient from "../client/jiraClient"
 import { IJiraIssue } from "../interfaces/issueInterfaces"
-import { COMPACT_SYMBOL, JIRA_KEY_REGEX } from "../interfaces/settingsInterfaces"
+import { COMPACT_SYMBOL, STATUS_ONLY_SYMBOL, JIRA_KEY_REGEX } from "../interfaces/settingsInterfaces"
 import ObjectsCache from "../objectsCache"
 import { SettingsData } from "../settings"
 import RC from "./renderingCommon"
@@ -11,10 +11,10 @@ import RC from "./renderingCommon"
 function convertInlineIssuesToTags(el: HTMLElement): void {
     if (SettingsData.inlineIssuePrefix) {
         let match
-        while (match = new RegExp(`${SettingsData.inlineIssuePrefix}(${COMPACT_SYMBOL}?|--)(${JIRA_KEY_REGEX})`).exec(el.innerHTML)) {
+        while (match = new RegExp(`${SettingsData.inlineIssuePrefix}(${STATUS_ONLY_SYMBOL}|${COMPACT_SYMBOL})?(${JIRA_KEY_REGEX})`).exec(el.innerHTML)) {
             // console.log({ match })
             const compact = match[1] === COMPACT_SYMBOL
-            const statusOnly = match[1] === '--'
+            const statusOnly = match[1] === STATUS_ONLY_SYMBOL
             const issueKey = match[2]
             const container = createSpan({ cls: 'ji-inline-issue jira-issue-container', attr: { 'data-issue-key': issueKey, 'data-compact': compact, 'data-status-only': statusOnly } })
             container.appendChild(RC.renderLoadingItem(issueKey, true))
@@ -54,9 +54,9 @@ export const InlineIssueRenderer = async (el: HTMLElement, ctx: MarkdownPostProc
                 value.replaceChildren(RC.renderIssueError(issueKey, cachedIssue.data as string))
             } else {
                 if (statusOnly) {
-                    value.replaceChildren(RC.renderIssueStatusOnly(cachedIssue.data as IJiraIssue))
+                    value.replaceChildren(RC.renderIssueStatusOnly(cachedIssue.data as IJiraIssue, true))
                 } else {
-                    value.replaceChildren(RC.renderIssue(cachedIssue.data as IJiraIssue, compact))
+                    value.replaceChildren(RC.renderIssue(cachedIssue.data as IJiraIssue, compact, true))
                 }
             }
         } else {
@@ -64,9 +64,9 @@ export const InlineIssueRenderer = async (el: HTMLElement, ctx: MarkdownPostProc
             JiraClient.getIssue(issueKey).then(newIssue => {
                 const issue = ObjectsCache.add(issueKey, newIssue).data as IJiraIssue
                 if (statusOnly) {
-                    value.replaceChildren(RC.renderIssueStatusOnly(issue))
+                    value.replaceChildren(RC.renderIssueStatusOnly(issue, true))
                 } else {
-                    value.replaceChildren(RC.renderIssue(issue, compact))
+                    value.replaceChildren(RC.renderIssue(issue, compact, true))
                 }
             }).catch(err => {
                 ObjectsCache.add(issueKey, err, true)

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -120,8 +120,13 @@ export default {
         el.replaceChildren(this.renderContainer([tagsRow]))
     },
 
-    renderIssue(issue: IJiraIssue, compact = false): HTMLElement {
-        const tagsRow = createDiv('ji-tags has-addons')
+    renderIssue(issue: IJiraIssue, compact = false, inline = false): HTMLElement {
+        let tagsRow
+        if (inline) {
+            tagsRow = createSpan({ cls: 'ji-tags has-addons' })
+        } else {
+            tagsRow = createDiv({ cls: 'ji-tags has-addons' })
+        }
         this.renderAccountColorBand(issue.account, tagsRow)
         if (issue.fields.issuetype.iconUrl) {
             createEl('img', {
@@ -142,8 +147,13 @@ export default {
         return tagsRow
     },
 
-    renderIssueStatusOnly(issue: IJiraIssue): HTMLElement {
-        const tagsRow = createDiv('ji-tags has-addons')
+    renderIssueStatusOnly(issue: IJiraIssue, inline = false): HTMLElement {
+        let tagsRow
+        if (inline) {
+            tagsRow = createSpan({ cls: 'ji-tags has-addons' })
+        } else {
+            tagsRow = createDiv({ cls: 'ji-tags has-addons' })
+        }
         this.renderAccountColorBand(issue.account, tagsRow)
         const statusColor = JIRA_STATUS_COLOR_MAP_BY_NAME[issue.fields.status.name] ||
             JIRA_STATUS_COLOR_MAP[issue.fields.status.statusCategory.colorName] ||

--- a/src/rendering/renderingCommon.ts
+++ b/src/rendering/renderingCommon.ts
@@ -142,6 +142,16 @@ export default {
         return tagsRow
     },
 
+    renderIssueStatusOnly(issue: IJiraIssue): HTMLElement {
+        const tagsRow = createDiv('ji-tags has-addons')
+        this.renderAccountColorBand(issue.account, tagsRow)
+        const statusColor = JIRA_STATUS_COLOR_MAP_BY_NAME[issue.fields.status.name] ||
+            JIRA_STATUS_COLOR_MAP[issue.fields.status.statusCategory.colorName] ||
+            'is-light'
+        createSpan({ cls: `ji-tag no-wrap ${statusColor}`, text: issue.fields.status.name, title: `${issue.key}: ${issue.fields.status.description}`, attr: { 'data-status': issue.fields.status.name }, parent: tagsRow })
+        return tagsRow
+    },
+
     renderIssueError(issueKey: string, message: string): HTMLElement {
         const tagsRow = createDiv('ji-tags has-addons')
         createSpan({ cls: 'ji-tag is-delete is-danger', parent: tagsRow })

--- a/src/rendering/searchFenceRenderer.ts
+++ b/src/rendering/searchFenceRenderer.ts
@@ -82,7 +82,8 @@ function getAccountBandStyle(account: IJiraIssueAccountSettings): string {
 
 function renderSearchFooter(rootEl: HTMLElement, searchView: SearchView, searchResults: IJiraSearchResults): HTMLElement {
     const searchFooter = createDiv({ cls: 'search-footer' })
-    const searchCount = `Total results: ${searchResults.total.toString()} - ${searchResults.account.alias}`
+    const total = searchResults.total ?? searchResults.issues?.length ?? 0
+    const searchCount = `Total results: ${total.toString()} - ${searchResults.account.alias}`
 
     if(SettingsData.showJiraLink) {
         createEl('a', {


### PR DESCRIPTION
- 🐛 Change search API path from /search to /search/jql
- ✨ Add default fields for search results when none specified
- ✨ Add status-only inline issue display mode with -- prefix
- 🏷️ Make search results pagination fields optional
- 🐛 Fix search footer total count handling for undefined values
- ♻️ Refactor inline issue rendering to support multiple display modes